### PR TITLE
[6.4] doc: make a separate CONTRIBUTION guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Development
+
+Be sure to clone `kibana_calendar_vis` under a folder `kibana_extra` that is in parallel to `kibana` in order to properly link scripts and tests.
+
+See the [kibana contributing guide](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md) for instructions setting up your development environment. Once you have completed that, use the following yarn scripts.
+
+  - `yarn kbn bootstrap`
+
+    Install dependencies and crosslink Kibana and all projects/plugins.
+
+    > ***IMPORTANT:*** Use this script instead of `yarn` to install dependencies when switching branches, and re-run it whenever your dependencies change.
+
+  - `yarn start`
+
+    Start kibana and have it include this plugin. You can pass any arguments that you would normally send to `bin/kibana`
+
+      ```
+      yarn start --elasticsearch.url http://localhost:9220
+      ```
+    > If the error occurs that says `plugin-helpers` does not exist, run `yarn add --dev link:../../kibana/packages/kbn-plugin-helpers` to link it for execution in this repo.
+
+  - `yarn build`
+
+    Build a distributable archive of your plugin.
+
+  - `yarn test`
+
+    Run all tests.
+
+    - `yarn test:browser`
+
+      Run the browser tests in a real web browser.
+
+    - `yarn test:jest`
+
+      Run jest tests in command line.
+
+    - `yarn test:functionalTests`
+
+      Run functional tests in command line and a real browser.
+
+For more information about any of these commands run `yarn ${task} --help`. For a full list of tasks checkout the `package.json` file, or run `yarn run`.

--- a/README.md
+++ b/README.md
@@ -26,44 +26,6 @@ As a reference, the following table describes the version compatibility with Kib
 | ---------- | ------- |
 | 6.4.0 | `./bin/kibana-plugin install https://github.com/aaronoah/kibana_calendar_vis/releases/download/v6.4.0/kibana_calendar_vis-6.4.0.zip`
 
-## Development
+## Contribution
 
-Be sure to clone `kibana_calendar_vis` under a folder `kibana_extra` that is in parallel to `kibana` in order to properly link scripts and tests.
-
-See the [kibana contributing guide](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md) for instructions setting up your development environment. Once you have completed that, use the following yarn scripts.
-
-  - `yarn kbn bootstrap`
-
-    Install dependencies and crosslink Kibana and all projects/plugins.
-
-    > ***IMPORTANT:*** Use this script instead of `yarn` to install dependencies when switching branches, and re-run it whenever your dependencies change.
-
-  - `yarn start`
-
-    Start kibana and have it include this plugin. You can pass any arguments that you would normally send to `bin/kibana`
-
-      ```
-      yarn start --elasticsearch.url http://localhost:9220
-      ```
-
-  - `yarn build`
-
-    Build a distributable archive of your plugin.
-
-  - `yarn test`
-
-    Run all tests.
-
-    - `yarn test:browser`
-
-      Run the browser tests in a real web browser.
-
-    - `yarn test:jest`
-
-      Run jest tests in command line.
-
-    - `yarn test:functionalTests`
-
-      Run functional tests in command line and a real browser.
-
-For more information about any of these commands run `yarn ${task} --help`. For a full list of tasks checkout the `package.json` file, or run `yarn run`.
+See [contribution guide](./CONTRIBUTING.md) for setting up development environment or raise any issues and suggestions under the [issues](https://github.com/aaronoah/kibana_calendar_vis/issues) page.


### PR DESCRIPTION
Backports the following commits to 6.4:
 - doc: make a separate CONTRIBUTION guide (9448ab5)